### PR TITLE
feat: Added startup command to replace tmux-resurrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # rost_sessionizer
 Cli-tool which integrates with tmux to manage sessions based on project folders. It is intended to work well with git worktrees.
+
+<!-- TODO: #12 update README <2025-07-13> -->

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -13,19 +13,25 @@ pub fn build_cli() -> Command {
         .name("rost_sessionizer")
         .author("Væñgír, <vaengir@gmx.de>")
         .version(crate_version!())
-        .about("Cli-tool which integrates with tmux to manage sessions based on project folders. It is intended to work well with git worktrees.")
+        .about(
+            "Cli-tool which integrates with tmux to manage sessions based on project folders.
+            It is intended to work well with git worktrees.",
+        )
         .arg_required_else_help(true)
-        .subcommand(Command::new("open")
-            .about("Open a new or switch to an existing session in tmux")
-            .arg(Arg::new("verbose")
-                .short('v')
-                .long("verbose")
-                .help("Use verbose output")
-                .action(ArgAction::SetTrue)))
-        .subcommand(Command::new("kill")
-            .about("Kill active session"))
-        .subcommand(Command::new("kill-all")
-            .about("Kill all active sessions"))
+        .subcommand(
+            Command::new("open")
+                .about("Open a new or switch to an existing session in tmux")
+                .arg(
+                    Arg::new("verbose")
+                        .short('v')
+                        .long("verbose")
+                        .help("Use verbose output")
+                        .action(ArgAction::SetTrue),
+                ),
+        )
+        .subcommand(Command::new("kill").about("Kill active session"))
+        .subcommand(Command::new("kill-all").about("Kill all active sessions"))
+        .subcommand(Command::new("startup").about("Start tmux with the default session"))
         .arg(
             Arg::new("generator")
                 .short('G')

--- a/src/commands/kill.rs
+++ b/src/commands/kill.rs
@@ -16,11 +16,10 @@ pub fn kill_current_session() -> Result<()> {
         utils::tmux_kill_session(&current_session)
             .with_context(|| format!("Error killing current session: '{current_session}'"))?;
     } else {
-        utils::tmux_command_without_output(&[
-            "display-message",
-            &format!("Can't kill the default session: '{DEFAULT_SESSION}'"),
-        ])
-        .context("Error sending notification")?;
+        utils::tmux_display_message(&format!(
+            "Can't kill the default session: '{DEFAULT_SESSION}'"
+        ))
+        .context("Error sending 'Can't kill the default session' notification")?;
     }
 
     Ok(())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,3 +7,4 @@
 pub mod cli;
 pub mod kill;
 pub mod open;
+pub mod startup;

--- a/src/commands/startup.rs
+++ b/src/commands/startup.rs
@@ -1,0 +1,59 @@
+use crate::{DEFAULT_SESSION, utils};
+use anyhow::{Context, Result};
+use std::env;
+
+pub fn startup() -> Result<()> {
+    match env::var("TMUX") {
+        Ok(val) if !val.is_empty() => {
+            let default_session_exists = utils::tmux_session_exisits(DEFAULT_SESSION)
+                .with_context(|| {
+                    format!("Error checking if default session '{DEFAULT_SESSION}' exists")
+                })?;
+            if default_session_exists {
+                utils::tmux_display_message(&format!(
+                    "The default session '{DEFAULT_SESSION}' is already running"
+                ))
+                .context("Error sending 'Default session already running' notification")?;
+            } else {
+                create_default_session().with_context(|| {
+                    format!("Error creating default session '{DEFAULT_SESSION}'")
+                })?;
+                utils::tmux_switch_client(DEFAULT_SESSION, Some(1)).with_context(|| {
+                    format!(
+                        "Error switching to first window of default session '{DEFAULT_SESSION}'"
+                    )
+                })?;
+            }
+        }
+        _ => {
+            create_default_session()
+                .with_context(|| format!("Error creating default session '{DEFAULT_SESSION}'"))?;
+            utils::tmux_command_without_output(&[
+                "attach-session",
+                "-t",
+                &format!("{DEFAULT_SESSION}:1"),
+            ])
+            .with_context(|| format!("Error attaching to default session '{DEFAULT_SESSION}'"))?;
+        }
+    };
+
+    Ok(())
+}
+
+fn create_default_session() -> Result<()> {
+    let home = env::var("HOME").context("Error getting $HOME")?;
+    utils::tmux_command_without_output(&["new-session", "-ds", DEFAULT_SESSION, "-c", &home])
+        .with_context(|| format!("Error creating default tmux session '{DEFAULT_SESSION}'"))?;
+    utils::tmux_command_without_output(&[
+        "new-window",
+        "-t",
+        &format!("{DEFAULT_SESSION}:2"),
+        "-c",
+        &home,
+    ])
+    .with_context(|| {
+        format!("Error creating second window for default session '{DEFAULT_SESSION}'")
+    })?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,9 @@ use anyhow::{Context, Result};
 use clap_complete::Shell;
 use rost_sessionizer::commands::{
     cli::{build_cli, print_completions},
-    kill, open,
+    kill, open, startup,
 };
 
-// TODO: #5 Replace tmux resurrect <2025-07-10>
 fn main() -> Result<()> {
     let args = build_cli().get_matches();
 
@@ -32,6 +31,9 @@ fn main() -> Result<()> {
         }
         Some(("kill-all", _sub_matches)) => {
             kill::kill_all_sessions().context("Error while trying to kill all sessions")?;
+        }
+        Some(("startup", _sub_matches)) => {
+            startup::startup().context("Error while starting default tmux session")?;
         }
         None => println!("Generated bash completion script"),
         e => unreachable!("Should be unreachable!: {:?}", e),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,6 +33,10 @@ pub(crate) fn tmux_kill_session(target_session: &str) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn tmux_display_message(message: &str) -> Result<()> {
+    tmux_command_without_output(&["display-message", message]).context("Error sending notification")
+}
+
 pub(crate) fn tmux_session_exisits(target_session: &str) -> Result<bool> {
     Command::new("tmux")
         .args(["has-session", "-t", target_session])


### PR DESCRIPTION
The command can be used to automatically setup tmux whenever a terminal is opened.

Refs: #5